### PR TITLE
Centralizes the domain configuration in one place - .env

### DIFF
--- a/user-service/.env
+++ b/user-service/.env
@@ -1,0 +1,2 @@
+KEYCLOAK_ISSUER_URI=https://stud-lucky-goldfish.ngrok-free.app/realms/multiple-auth
+KEYCLOAK_HOSTNAME=https://stud-lucky-goldfish.ngrok-free.app

--- a/user-service/docker-compose.yaml
+++ b/user-service/docker-compose.yaml
@@ -14,6 +14,8 @@ services:
     ports:
       - "8081:9090"
       - "8003:8003"
+    env_file:
+      - .env
     environment:
       LOG_LEVEL: info
       POSTGRESQL_HOST: postgres
@@ -50,7 +52,7 @@ services:
     volumes:
       - ./scripts/health-check.sh:/opt/scripts/health-check.sh
       - ./testing/import:/opt/keycloak/data/import:rw
-      - ./testing/conf/keycloak.conf:/opt/keycloak/conf/keycloak.conf:ro
+#      - ./testing/conf/keycloak.conf:/opt/keycloak/conf/keycloak.conf:ro
     command:
       - "-v"
       - "start-dev"
@@ -62,14 +64,19 @@ services:
       - "--spi-x509cert-lookup-nginx-ssl-cert-chain-prefix=CERT_CHAIN"
       - "--spi-x509cert-lookup-nginx-certificate-chain-length=2"
       - "--spi-sms-spi-service-test=true"
+    env_file:
+      - .env
     environment:
       DEBUG: "true"
       DEBUG_PORT: "*:8001"
       KEYCLOAK_ADMIN: admin
       KEYCLOAK_ADMIN_PASSWORD: admin
       KC_DB: postgres
+      KC_PROXY: edge
       KC_DB_PASSWORD: "password1"
       KC_DB_USERNAME: localdevuser
+      KC_HOSTNAME: ${KEYCLOAK_HOSTNAME}
+      KC_HOSTNAME_ADMIN: ${KEYCLOAK_HOSTNAME}
       KC_DB_URL: "jdbc:postgresql://db:5432/keycloak"
       "jgroups.dns.query": keycloak
     healthcheck:

--- a/user-service/testing/conf/keycloak.conf
+++ b/user-service/testing/conf/keycloak.conf
@@ -1,5 +1,6 @@
+# unused for now as we're referencing the env variables directly from docker-compose.yaml
 proxy=edge
-hostname=https://f86a-93-86-51-26.ngrok-free.app
-hostname-admin=https://f86a-93-86-51-26.ngrok-free.app
+hostname=https://stud-lucky-goldfish.ngrok-free.app/
+hostname-admin=https://stud-lucky-goldfish.ngrok-free.app/
 log=console
 log-level=info,org.keycloak.events:debug

--- a/user-service/testing/import/realm-export (21).json
+++ b/user-service/testing/import/realm-export (21).json
@@ -1799,6 +1799,7 @@
   "clientAuthenticationFlow": "clients",
   "dockerAuthenticationFlow": "docker auth",
   "attributes": {
+    "frontendUrl": "${KEYCLOAK_HOSTNAME}",
     "cibaBackchannelTokenDeliveryMode": "poll",
     "cibaExpiresIn": "120",
     "cibaAuthRequestedUserHint": "login_hint",


### PR DESCRIPTION
this will setup frontend url for multiple-auth realm, hostname for Keycloak based on the .env entry 

in this example it's ngrok domain